### PR TITLE
fix: update draggable import path

### DIFF
--- a/lumen-draggable-dashboard.py
+++ b/lumen-draggable-dashboard.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import base64
 import json
 from streamlit_elements import elements, mui, html, sync, event
-from streamlit_elements.modules import draggable
+from streamlit_elements.draggable import draggable
 
 # Page configuration
 st.set_page_config(

--- a/lumen-streamlit-dashboard.py
+++ b/lumen-streamlit-dashboard.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import base64
 import json
 from streamlit_elements import elements, mui, html, sync, event
-from streamlit_elements.modules import draggable
+from streamlit_elements.draggable import draggable
 
 # Page configuration
 st.set_page_config(


### PR DESCRIPTION
## Summary
- fix streamlit-elements draggable import path for compatibility

## Testing
- `python -c "import streamlit_elements; print(streamlit_elements.__version__)"`
- `streamlit run lumen-draggable-dashboard.py`
- `python -m py_compile lumen-draggable-dashboard.py lumen-streamlit-dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b07e8f4f6c832983d12ac1d0cb272f