### PR TITLE
Seed database from CSV when empty

### DIFF
--- a/lumen-draggable-dashboard.py
+++ b/lumen-draggable-dashboard.py
@@ -9,6 +9,7 @@ import sqlite3
 from datetime import datetime, timedelta
 import base64
 import json
+import os
 # streamlit_elements.draggable has been removed; use dashboard.Grid instead
 
 from streamlit_elements import elements, mui, html, sync, event, dashboard
@@ -125,8 +126,19 @@ def init_database():
             timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
     ''')
-    
+
     conn.commit()
+
+    # Load initial data if the initiatives table is empty
+    c.execute('SELECT COUNT(*) FROM initiatives')
+    if c.fetchone()[0] == 0:
+        csv_path = os.path.join(os.path.dirname(__file__), "lumen_initiatives.csv")
+        if os.path.exists(csv_path):
+            df = pd.read_csv(csv_path)
+            df["is_deleted"] = 0
+            df.to_sql("initiatives", conn, if_exists="append", index=False)
+            conn.commit()
+
     conn.close()
 
 def get_initiatives_from_db():


### PR DESCRIPTION
## Summary
- Import default initiatives from `lumen_initiatives.csv` during database initialization when the `initiatives` table is empty
- Ensure imported initiatives are marked active so cards render on first launch

## Testing
- `python -m py_compile lumen-draggable-dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b08a4d656c8329a45f8d4bc6198cad