### PR TITLE
Fix dashboard items not rendering

### DIFF
--- a/lumen-draggable-dashboard.py
+++ b/lumen-draggable-dashboard.py
@@ -388,27 +388,28 @@ def create_draggable_matrix():
                         "blue": "#007aff",
                     }
 
-                    with mui.Paper(
-                        key=str(row["id"]),
-                        className="drag-handle",
-                        elevation=3,
-                        onClick=lambda e, item_id=row["id"]: handle_click(item_id),
-                        sx={
-                            "padding": "12px",
-                            "borderRadius": "8px",
-                            "background": colors.get(row["color"], "#8e8e93"),
-                            "color": "white",
-                            "cursor": "move",
-                            "minWidth": "120px",
-                            "maxWidth": "150px",
-                            "textAlign": "center",
-                            "&:hover": {"transform": "scale(1.05)", "boxShadow": 4},
-                        },
-                    ):
-                        mui.Typography(
-                            row["title"][:20] + "..." if len(row["title"]) > 20 else row["title"],
-                            sx={"fontSize": "12px", "fontWeight": 500},
-                        )
+                    # Each paper must be wrapped in dashboard.Item so the grid can position it.
+                    with dashboard.Item(str(row["id"])):
+                        with mui.Paper(
+                            className="drag-handle",
+                            elevation=3,
+                            onClick=lambda e, item_id=row["id"]: handle_click(item_id),
+                            sx={
+                                "padding": "12px",
+                                "borderRadius": "8px",
+                                "background": colors.get(row["color"], "#8e8e93"),
+                                "color": "white",
+                                "cursor": "move",
+                                "minWidth": "120px",
+                                "maxWidth": "150px",
+                                "textAlign": "center",
+                                "&:hover": {"transform": "scale(1.05)", "boxShadow": 4},
+                            },
+                        ):
+                            mui.Typography(
+                                row["title"][:20] + "..." if len(row["title"]) > 20 else row["title"],
+                                sx={"fontSize": "12px", "fontWeight": 500},
+                            )
 
 def show_dashboard():
     """Display the dashboard with draggable matrix"""


### PR DESCRIPTION
## Summary
- Ensure draggable cards are rendered by wrapping each note in a `dashboard.Item` container

## Testing
- `python -m py_compile lumen-draggable-dashboard.py`
- `streamlit run lumen-draggable-dashboard.py >/tmp/streamlit.log 2>&1 &`


------
https://chatgpt.com/codex/tasks/task_e_68b08b665324832995f4481b808f66bf