### PR TITLE
Add draggable sticky notes with editable details

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,8 @@
             box-shadow: 2px 2px 5px rgba(0,0,0,0.2);
             transition: box-shadow 0.3s ease, transform 0.3s ease;
             font-weight: 500;
-            max-width: 120px;
+            width: 150px;
+            min-height: 100px;
             word-wrap: break-word;
             transform: rotate(-2deg);
             z-index: 100;
@@ -602,6 +603,9 @@
                 <h3>Recommended Actions:</h3>
                 <p id="modalActions"></p>
             </div>
+            <div class="form-actions">
+                <button class="btn" onclick="openEditFromDetail()">Edit</button>
+            </div>
         </div>
     </div>
     
@@ -690,9 +694,11 @@
         
         let currentPositions = {};
         let isDragging = false;
+        let hasMoved = false;
         let currentElement = null;
         let offsetX, offsetY;
         let nextId = 29;
+        let currentDetailId = null;
         
         // Initialize the matrix and table
         function init() {
@@ -754,11 +760,11 @@
             
             // Store position
             currentPositions[item.id] = position;
-            
+
             // Add event listeners
             note.addEventListener('mousedown', startDrag);
-            note.addEventListener('dblclick', showDetails);
-            
+            note.addEventListener('click', handleNoteClick);
+
             container.appendChild(note);
         }
         
@@ -767,12 +773,12 @@
             if (e.target.classList.contains('edit-btn') || e.target.classList.contains('delete-btn')) return;
             
             isDragging = true;
+            hasMoved = false;
             currentElement = e.target.closest('.sticky-note');
-            currentElement.classList.add('dragging');
-            
+
             const rect = currentElement.getBoundingClientRect();
             const containerRect = document.getElementById('matrixContainer').getBoundingClientRect();
-            
+
             offsetX = e.clientX - rect.left;
             offsetY = e.clientY - rect.top;
             
@@ -784,7 +790,12 @@
         
         function drag(e) {
             if (!isDragging || !currentElement) return;
-            
+
+            hasMoved = true;
+            if (!currentElement.classList.contains('dragging')) {
+                currentElement.classList.add('dragging');
+            }
+
             const containerRect = document.getElementById('matrixContainer').getBoundingClientRect();
             
             let x = e.clientX - containerRect.left - offsetX;
@@ -815,9 +826,18 @@
             }
             isDragging = false;
             currentElement = null;
-            
+
             document.removeEventListener('mousemove', drag);
             document.removeEventListener('mouseup', stopDrag);
+        }
+
+        function handleNoteClick(e) {
+            if (hasMoved) {
+                hasMoved = false;
+                return;
+            }
+            const element = e.currentTarget;
+            showDetailsById(element.getAttribute('data-id'));
         }
         
         function populateTable() {
@@ -1030,26 +1050,27 @@
             }
         }
         
-        function showDetails(e) {
-            const element = e.target.closest('.sticky-note');
-            if (element) {
-                showDetailsById(element.getAttribute('data-id'));
-            }
-        }
-        
         function showDetailsById(id) {
             const item = initiatives.find(i => i.id == id);
             if (!item) return;
-            
+
+            currentDetailId = id;
             const position = currentPositions[id] || {x: item.initialX, y: item.initialY};
-            
+
             document.getElementById('modalTitle').textContent = item.title;
             document.getElementById('modalDetails').textContent = item.details || 'No details provided';
-            document.getElementById('modalPosition').textContent = 
+            document.getElementById('modalPosition').textContent =
                 `Value: ${getValueFromPosition(position.y)}, Effort: ${getEffortFromPosition(position.x)}`;
             document.getElementById('modalActions').textContent = getRecommendedActions(position.x, position.y);
-            
+
             document.getElementById('detailModal').style.display = 'block';
+        }
+
+        function openEditFromDetail() {
+            if (currentDetailId !== null) {
+                closeModal('detailModal');
+                openEditModal(currentDetailId);
+            }
         }
         
         function getRecommendedActions(x, y) {


### PR DESCRIPTION
## Summary
- style matrix items as fixed-size sticky notes for easier reading
- allow single-click selection with drag-aware logic on each note
- enable editing directly from the details modal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0adef95ac832991477e5797f9ae77