### PR TITLE
Add draggable sticky notes with editable details

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,12 @@
             color: #7f8c8d;
             font-size: 1.1em;
         }
+
+        .version {
+            margin-top: 4px;
+            color: #a0aec0;
+            font-size: 0.9em;
+        }
         
         .controls {
             margin: 20px 0;
@@ -158,19 +164,23 @@
         
         .sticky-note {
             position: absolute;
-            padding: 8px;
-            border-radius: 3px;
+            padding: 8px 10px;
+            border-radius: 4px;
             cursor: move;
-            font-size: 11px;
-            line-height: 1.3;
+            font-size: 12px;
+            line-height: 1.4;
             box-shadow: 2px 2px 5px rgba(0,0,0,0.2);
             transition: box-shadow 0.3s ease, transform 0.3s ease;
             font-weight: 500;
-            max-width: 120px;
+            width: 150px;
+            min-height: 110px;
             word-wrap: break-word;
             transform: rotate(-2deg);
             z-index: 100;
             user-select: none;
+            display: flex;
+            align-items: flex-start;
+            justify-content: flex-start;
         }
         
         .sticky-note:hover {
@@ -505,6 +515,7 @@
         <div class="header">
             <h1>Lumen Workshop Strategic Initiative Matrix</h1>
             <p>Interactive 2x2 Value/Effort Analysis - Drag to reposition, Double-click to view details</p>
+            <div id="version" class="version"></div>
         </div>
         
         <div class="controls">
@@ -602,6 +613,9 @@
                 <h3>Recommended Actions:</h3>
                 <p id="modalActions"></p>
             </div>
+            <div class="form-actions">
+                <button class="btn" onclick="openEditFromDetail()">Edit</button>
+            </div>
         </div>
     </div>
     
@@ -656,6 +670,9 @@
     </div>
     
     <script>
+        // Application version for cache-busting / verification
+        const DASHBOARD_VERSION = '1.1.0';
+
         // Initiative data
         let initiatives = [
             {id: 1, title: "Prioritize CommMgmt Strategy", details: "Establish clear communication management strategy and framework", color: "pink", category: "Strategic/Process", initialX: 10, initialY: 15},
@@ -690,15 +707,21 @@
         
         let currentPositions = {};
         let isDragging = false;
+        let hasMoved = false;
         let currentElement = null;
         let offsetX, offsetY;
         let nextId = 29;
+        let currentDetailId = null;
         
         // Initialize the matrix and table
         function init() {
             loadSavedData();
             createStickyNotes();
             populateTable();
+            const versionEl = document.getElementById('version');
+            if (versionEl) {
+                versionEl.textContent = `Version ${DASHBOARD_VERSION}`;
+            }
         }
         
         function createStickyNotes() {
@@ -754,11 +777,11 @@
             
             // Store position
             currentPositions[item.id] = position;
-            
+
             // Add event listeners
             note.addEventListener('mousedown', startDrag);
-            note.addEventListener('dblclick', showDetails);
-            
+            note.addEventListener('click', handleNoteClick);
+
             container.appendChild(note);
         }
         
@@ -767,12 +790,12 @@
             if (e.target.classList.contains('edit-btn') || e.target.classList.contains('delete-btn')) return;
             
             isDragging = true;
+            hasMoved = false;
             currentElement = e.target.closest('.sticky-note');
-            currentElement.classList.add('dragging');
-            
+
             const rect = currentElement.getBoundingClientRect();
             const containerRect = document.getElementById('matrixContainer').getBoundingClientRect();
-            
+
             offsetX = e.clientX - rect.left;
             offsetY = e.clientY - rect.top;
             
@@ -784,7 +807,12 @@
         
         function drag(e) {
             if (!isDragging || !currentElement) return;
-            
+
+            hasMoved = true;
+            if (!currentElement.classList.contains('dragging')) {
+                currentElement.classList.add('dragging');
+            }
+
             const containerRect = document.getElementById('matrixContainer').getBoundingClientRect();
             
             let x = e.clientX - containerRect.left - offsetX;
@@ -815,9 +843,18 @@
             }
             isDragging = false;
             currentElement = null;
-            
+
             document.removeEventListener('mousemove', drag);
             document.removeEventListener('mouseup', stopDrag);
+        }
+
+        function handleNoteClick(e) {
+            if (hasMoved) {
+                hasMoved = false;
+                return;
+            }
+            const element = e.currentTarget;
+            showDetailsById(element.getAttribute('data-id'));
         }
         
         function populateTable() {
@@ -1030,26 +1067,27 @@
             }
         }
         
-        function showDetails(e) {
-            const element = e.target.closest('.sticky-note');
-            if (element) {
-                showDetailsById(element.getAttribute('data-id'));
-            }
-        }
-        
         function showDetailsById(id) {
             const item = initiatives.find(i => i.id == id);
             if (!item) return;
-            
+
+            currentDetailId = id;
             const position = currentPositions[id] || {x: item.initialX, y: item.initialY};
-            
+
             document.getElementById('modalTitle').textContent = item.title;
             document.getElementById('modalDetails').textContent = item.details || 'No details provided';
-            document.getElementById('modalPosition').textContent = 
+            document.getElementById('modalPosition').textContent =
                 `Value: ${getValueFromPosition(position.y)}, Effort: ${getEffortFromPosition(position.x)}`;
             document.getElementById('modalActions').textContent = getRecommendedActions(position.x, position.y);
-            
+
             document.getElementById('detailModal').style.display = 'block';
+        }
+
+        function openEditFromDetail() {
+            if (currentDetailId !== null) {
+                closeModal('detailModal');
+                openEditModal(currentDetailId);
+            }
         }
         
         function getRecommendedActions(x, y) {


### PR DESCRIPTION
## Summary
- style matrix items as fixed-size sticky notes for easier reading
- allow single-click selection with drag-aware logic on each note
- enable editing directly from the details modal
- add visible dashboard version string

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0adef95ac832991477e5797f9ae77