### PR TITLE
Load static HTML dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,31 +1,29 @@
 import streamlit as st
+from pathlib import Path
+
 from auth import login
-from db import init_db, add_initiative
-from ui import load_css, create_draggable_matrix
+from db import init_db
 
 
 def main() -> None:
-    st.set_page_config(page_title="Lumen Strategic Dashboard", page_icon="⊙", layout="wide")
+    """Load and display the static index.html page after authentication."""
+    st.set_page_config(
+        page_title="Lumen Strategic Dashboard",
+        page_icon="⊙",
+        layout="wide",
+    )
+
     init_db()
-    if not login():
+    authenticator, authenticated = login()
+    if not authenticated:
         st.stop()
+    authenticator.logout("Logout", "main")
 
-    load_css()
-    st.title("Lumen Strategic Dashboard")
+    index_path = Path(__file__).with_name("index.html")
+    with index_path.open(encoding="utf-8") as f:
+        html = f.read()
 
-    with st.sidebar:
-        st.header("Add Initiative")
-        with st.form("add_form"):
-            title = st.text_input("Title")
-            details = st.text_area("Details")
-            color = st.selectbox("Color", ["pink", "yellow", "green", "blue"])
-            category = st.text_input("Category")
-            if st.form_submit_button("Add"):
-                add_initiative(title, details, color, category, 50, 50, st.session_state.get("username", "user"))
-                st.success("Added initiative")
-                st.rerun()
-
-    create_draggable_matrix(st.session_state.get("username", "user"))
+    st.components.v1.html(html, height=0, scrolling=False)
 
 
 if __name__ == "__main__":

--- a/auth.py
+++ b/auth.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import streamlit_authenticator as stauth
+from typing import Tuple
 
 # Pre-hashed password for user "admin" with password "admin"
 _CREDENTIALS = {
@@ -12,8 +13,8 @@ _CREDENTIALS = {
 }
 
 
-def login() -> bool:
-    """Render login form and return authentication status."""
+def login() -> Tuple[stauth.Authenticate, bool]:
+    """Render login form and return the authenticator and status."""
     authenticator = stauth.Authenticate(
         _CREDENTIALS,
         "lumen_dashboard",
@@ -24,8 +25,6 @@ def login() -> bool:
     auth_status = st.session_state.get("authentication_status")
     if auth_status:
         st.session_state["username"] = st.session_state.get("username")
-        authenticator.logout("Logout", "sidebar")
-        return True
     elif auth_status is False:
         st.error("Invalid credentials")
-    return False
+    return authenticator, bool(auth_status)

--- a/index.html
+++ b/index.html
@@ -10,7 +10,11 @@
             padding: 0;
             box-sizing: border-box;
         }
-        
+
+        html, body {
+            height: 100%;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -32,6 +36,7 @@
             margin-bottom: 30px;
             padding-bottom: 20px;
             border-bottom: 3px solid #e0e0e0;
+            position: relative;
         }
         
         .header h1 {
@@ -43,6 +48,15 @@
         .header p {
             color: #7f8c8d;
             font-size: 1.1em;
+        }
+
+        .version {
+            position: absolute;
+            top: 0;
+            right: 0;
+            color: #4a5568;
+            font-size: 0.9em;
+            font-weight: 500;
         }
         
         .controls {
@@ -158,19 +172,24 @@
         
         .sticky-note {
             position: absolute;
-            padding: 8px;
-            border-radius: 3px;
+            padding: 10px 12px;
+            border-radius: 4px;
             cursor: move;
-            font-size: 11px;
-            line-height: 1.3;
+            font-size: 14px;
+            line-height: 1.4;
             box-shadow: 2px 2px 5px rgba(0,0,0,0.2);
             transition: box-shadow 0.3s ease, transform 0.3s ease;
             font-weight: 500;
-            max-width: 120px;
+            width: 160px;
+            min-height: 120px;
             word-wrap: break-word;
             transform: rotate(-2deg);
             z-index: 100;
             user-select: none;
+            display: flex;
+            align-items: flex-start;
+            justify-content: flex-start;
+            font-family: 'Comic Sans MS', 'Marker Felt', cursive;
         }
         
         .sticky-note:hover {
@@ -505,6 +524,7 @@
         <div class="header">
             <h1>Lumen Workshop Strategic Initiative Matrix</h1>
             <p>Interactive 2x2 Value/Effort Analysis - Drag to reposition, Double-click to view details</p>
+            <div id="version" class="version"></div>
         </div>
         
         <div class="controls">
@@ -602,6 +622,9 @@
                 <h3>Recommended Actions:</h3>
                 <p id="modalActions"></p>
             </div>
+            <div class="form-actions">
+                <button class="btn" onclick="openEditFromDetail()">Edit</button>
+            </div>
         </div>
     </div>
     
@@ -656,6 +679,9 @@
     </div>
     
     <script>
+        // Application version for cache-busting / verification
+        const DASHBOARD_VERSION = '1.1.3';
+
         // Initiative data
         let initiatives = [
             {id: 1, title: "Prioritize CommMgmt Strategy", details: "Establish clear communication management strategy and framework", color: "pink", category: "Strategic/Process", initialX: 10, initialY: 15},
@@ -693,12 +719,17 @@
         let currentElement = null;
         let offsetX, offsetY;
         let nextId = 29;
+        let currentDetailId = null;
         
         // Initialize the matrix and table
         function init() {
             loadSavedData();
             createStickyNotes();
             populateTable();
+            const versionEl = document.getElementById('version');
+            if (versionEl) {
+                versionEl.textContent = `Version ${DASHBOARD_VERSION}`;
+            }
         }
         
         function createStickyNotes() {
@@ -754,11 +785,11 @@
             
             // Store position
             currentPositions[item.id] = position;
-            
+
             // Add event listeners
             note.addEventListener('mousedown', startDrag);
-            note.addEventListener('dblclick', showDetails);
-            
+            note.addEventListener('dblclick', handleNoteDblClick);
+
             container.appendChild(note);
         }
         
@@ -768,11 +799,10 @@
             
             isDragging = true;
             currentElement = e.target.closest('.sticky-note');
-            currentElement.classList.add('dragging');
-            
+
             const rect = currentElement.getBoundingClientRect();
             const containerRect = document.getElementById('matrixContainer').getBoundingClientRect();
-            
+
             offsetX = e.clientX - rect.left;
             offsetY = e.clientY - rect.top;
             
@@ -784,7 +814,11 @@
         
         function drag(e) {
             if (!isDragging || !currentElement) return;
-            
+
+            if (!currentElement.classList.contains('dragging')) {
+                currentElement.classList.add('dragging');
+            }
+
             const containerRect = document.getElementById('matrixContainer').getBoundingClientRect();
             
             let x = e.clientX - containerRect.left - offsetX;
@@ -815,9 +849,14 @@
             }
             isDragging = false;
             currentElement = null;
-            
+
             document.removeEventListener('mousemove', drag);
             document.removeEventListener('mouseup', stopDrag);
+        }
+
+        function handleNoteDblClick(e) {
+            const element = e.currentTarget;
+            showDetailsById(element.getAttribute('data-id'));
         }
         
         function populateTable() {
@@ -1030,26 +1069,27 @@
             }
         }
         
-        function showDetails(e) {
-            const element = e.target.closest('.sticky-note');
-            if (element) {
-                showDetailsById(element.getAttribute('data-id'));
-            }
-        }
-        
         function showDetailsById(id) {
             const item = initiatives.find(i => i.id == id);
             if (!item) return;
-            
+
+            currentDetailId = id;
             const position = currentPositions[id] || {x: item.initialX, y: item.initialY};
-            
+
             document.getElementById('modalTitle').textContent = item.title;
             document.getElementById('modalDetails').textContent = item.details || 'No details provided';
-            document.getElementById('modalPosition').textContent = 
+            document.getElementById('modalPosition').textContent =
                 `Value: ${getValueFromPosition(position.y)}, Effort: ${getEffortFromPosition(position.x)}`;
             document.getElementById('modalActions').textContent = getRecommendedActions(position.x, position.y);
-            
+
             document.getElementById('detailModal').style.display = 'block';
+        }
+
+        function openEditFromDetail() {
+            if (currentDetailId !== null) {
+                closeModal('detailModal');
+                openEditModal(currentDetailId);
+            }
         }
         
         function getRecommendedActions(x, y) {
@@ -1193,8 +1233,27 @@
             }
         }
         
-        // Initialize on load
-        window.addEventListener('load', init);
+        // Adjust iframe height so the dashboard fills the browser window
+        function resizeFrame() {
+            const height = document.documentElement.scrollHeight;
+            window.parent.postMessage({ type: 'streamlit:height', height }, '*');
+        }
+
+        // Watch for changes that affect document height
+        function setupResizeObserver() {
+            if (window.ResizeObserver) {
+                const observer = new ResizeObserver(() => resizeFrame());
+                observer.observe(document.body);
+            }
+        }
+
+        // Initialize on load and set initial height
+        window.addEventListener('load', () => {
+            init();
+            resizeFrame();
+            setupResizeObserver();
+        });
+        window.addEventListener('resize', resizeFrame);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render bundled `index.html` inside the Streamlit app after login
- replace sidebar logout with a main-page logout button
- let the embedded dashboard expand to the full browser height
- style initiative markers as draggable sticky notes that open details on double-click
- bump dashboard version to 1.1.3 for cache-busting verification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0adef95ac832991477e5797f9ae77