### PR TITLE
Fix Streamlit iframe resize messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1239,7 +1239,11 @@
         // Adjust iframe height so the dashboard fills the browser window
         function resizeFrame() {
             const height = document.documentElement.scrollHeight;
-            window.parent.postMessage({ type: 'streamlit:height', height }, '*');
+            window.parent.postMessage({
+                type: 'streamlit:setFrameHeight',
+                height,
+                isStreamlitMessage: true
+            }, '*');
         }
 
         // Watch for changes that affect document height


### PR DESCRIPTION
## Summary
- ensure embedded dashboard uses `streamlit:setFrameHeight` with `isStreamlitMessage: true` for iframe resizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf739b0c8329a2541434c9b5f4a6