### PR TITLE
Fix Streamlit iframe resize messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1238,8 +1238,13 @@
         
         // Adjust iframe height so the dashboard fills the browser window
         function resizeFrame() {
-            const height = document.documentElement.scrollHeight;
-            window.parent.postMessage({ type: 'streamlit:height', height }, '*');
+            const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+            const height = Math.max(document.documentElement.scrollHeight, viewportHeight);
+            window.parent.postMessage({
+                type: 'streamlit:setFrameHeight',
+                height,
+                isStreamlitMessage: true
+            }, '*');
         }
 
         // Watch for changes that affect document height
@@ -1258,6 +1263,9 @@
             setupResizeObserver();
         });
         window.addEventListener('resize', resizeFrame);
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', resizeFrame);
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure embedded dashboard uses `streamlit:setFrameHeight` with `isStreamlitMessage: true` for iframe resizing
- watch `visualViewport` to update height on vertical changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf739b0c8329a2541434c9b5f4a6