### PR TITLE
Fix Streamlit iframe resize messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,13 +12,13 @@
         }
 
         html, body {
+            width: 100%;
             height: 100%;
         }
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
             padding: 20px;
         }
         
@@ -1238,26 +1238,36 @@
         
         // Adjust iframe height so the dashboard fills the browser window
         function resizeFrame() {
-            const height = document.documentElement.scrollHeight;
-            window.parent.postMessage({ type: 'streamlit:height', height }, '*');
+            const docHeight = document.documentElement.scrollHeight;
+            const viewportHeight = window.visualViewport ? window.visualViewport.height : 0;
+            const height = Math.max(docHeight, viewportHeight, 1000);
+            window.parent.postMessage({
+                type: 'streamlit:setFrameHeight',
+                height,
+                isStreamlitMessage: true
+            }, '*');
         }
 
-        // Watch for changes that affect document height
-        function setupResizeObserver() {
+        // Watch for changes and repeatedly set height to avoid race conditions
+        function setupFrameSizing() {
+            resizeFrame();
+            // run again in case Streamlit resets the height after initial render
+            setTimeout(resizeFrame, 100);
+
             if (window.ResizeObserver) {
-                const observer = new ResizeObserver(() => resizeFrame());
-                observer.observe(document.body);
+                new ResizeObserver(resizeFrame).observe(document.body);
+            }
+
+            window.addEventListener('resize', resizeFrame);
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', resizeFrame);
             }
         }
 
-
-        // Initialize on load and set initial height
         window.addEventListener('load', () => {
             init();
-            resizeFrame();
-            setupResizeObserver();
+            setupFrameSizing();
         });
-        window.addEventListener('resize', resizeFrame);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- compute dashboard height from document and viewport
- retry `streamlit:setFrameHeight` after load and on future resizes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf739b0c8329a2541434c9b5f4a6