### PR TITLE
Embed Streamlit component lib for iframe sizing

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ def main() -> None:
     with index_path.open(encoding="utf-8") as f:
         html = f.read()
 
-    st.components.v1.html(html, height=0, scrolling=False)
+    st.components.v1.html(html, height=1000, scrolling=False)
 
 
 if __name__ == "__main__":

--- a/index.html
+++ b/index.html
@@ -12,13 +12,13 @@
         }
 
         html, body {
+            width: 100%;
             height: 100%;
         }
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
             padding: 20px;
         }
         
@@ -521,6 +521,7 @@
             font-size: 12px;
         }
     </style>
+    <script src="https://unpkg.com/streamlit-component-lib@latest/dist/index.js"></script>
 </head>
 <body>
     <div class="container">
@@ -681,6 +682,7 @@
         </div>
     </div>
     
+    <script src="https://unpkg.com/@streamlit/component-lib@1.0.0/index.js"></script>
     <script>
         // Application version for cache-busting / verification
         const DASHBOARD_VERSION = '1.1.3';
@@ -1238,26 +1240,32 @@
         
         // Adjust iframe height so the dashboard fills the browser window
         function resizeFrame() {
-            const height = document.documentElement.scrollHeight;
-            window.parent.postMessage({ type: 'streamlit:height', height }, '*');
+            const docHeight = document.documentElement.scrollHeight;
+            const viewportHeight = window.visualViewport ? window.visualViewport.height : 0;
+            const height = Math.max(docHeight, viewportHeight, 1000);
+            Streamlit.setFrameHeight(height);
         }
 
-        // Watch for changes that affect document height
-        function setupResizeObserver() {
+        // Watch for changes and repeatedly set height to avoid race conditions
+        function setupFrameSizing() {
+            resizeFrame();
+            // run again in case Streamlit resets the height after initial render
+            setTimeout(resizeFrame, 100);
+
             if (window.ResizeObserver) {
-                const observer = new ResizeObserver(() => resizeFrame());
-                observer.observe(document.body);
+                new ResizeObserver(resizeFrame).observe(document.body);
+            }
+
+            window.addEventListener('resize', resizeFrame);
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', resizeFrame);
             }
         }
 
-
-        // Initialize on load and set initial height
         window.addEventListener('load', () => {
             init();
-            resizeFrame();
-            setupResizeObserver();
+            setupFrameSizing();
         });
-        window.addEventListener('resize', resizeFrame);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Streamlit component library from unpkg
- set an initial 1000px iframe height in Streamlit to avoid zero-height rendering
- use `Streamlit.setFrameHeight` for dashboard resizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf739b0c8329a2541434c9b5f4a6