### PR TITLE
Fix iframe height calculation to prevent dashboard cutoff

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,13 +17,51 @@ def main() -> None:
     authenticator, authenticated = login()
     if not authenticated:
         st.stop()
-    authenticator.logout("Logout", "main")
+    st.markdown(
+        """
+        <style>
+            /* Make the entire Streamlit page adopt the dashboard background */
+            html, body {
+                margin: 0;
+                padding: 0;
+                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            }
+
+            div[data-testid="stApp"] {
+                background: transparent;
+            }
+
+            /* Remove Streamlit's default padding so the iframe reaches the edges */
+            div[data-testid="stAppViewContainer"] {
+                padding: 0;
+                background: transparent;
+            }
+            div[data-testid="stAppViewContainer"] > .main {
+                padding: 0;
+                background: transparent;
+            }
+            div[data-testid="stAppViewContainer"] > .main .block-container {
+                padding: 0;
+                margin: 0;
+                background: transparent;
+            }
+            /* Hide Streamlit's default header to remove extra white space */
+            header[data-testid="stHeader"] {
+                display: none;
+            }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
 
     index_path = Path(__file__).with_name("index.html")
     with index_path.open(encoding="utf-8") as f:
         html = f.read()
 
-    st.components.v1.html(html, height=0, scrolling=False)
+    st.components.v1.html(html, height=1000, scrolling=False)
+
+    # Place logout button below the dashboard instead of at the top
+    authenticator.logout("Logout", "main")
 
 
 if __name__ == "__main__":

--- a/index.html
+++ b/index.html
@@ -12,13 +12,13 @@
         }
 
         html, body {
-            height: 100%;
+            width: 100%;
+            min-height: 100%;
         }
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
             padding: 20px;
         }
         
@@ -29,6 +29,7 @@
             border-radius: 20px;
             box-shadow: 0 20px 60px rgba(0,0,0,0.3);
             padding: 30px;
+            min-height: calc(100vh - 40px);
         }
         
         .header {
@@ -105,7 +106,8 @@
         .matrix-container {
             position: relative;
             width: 100%;
-            height: 700px;
+            min-height: 700px;
+            height: calc(100vh - 240px);
             background: #f8f9fa;
             border: 2px solid #dee2e6;
             border-radius: 10px;
@@ -1236,28 +1238,52 @@
             }
         }
         
-        // Adjust iframe height so the dashboard fills the browser window
-        function resizeFrame() {
-            const height = document.documentElement.scrollHeight;
-            window.parent.postMessage({ type: 'streamlit:height', height }, '*');
-        }
-
-        // Watch for changes that affect document height
-        function setupResizeObserver() {
-            if (window.ResizeObserver) {
-                const observer = new ResizeObserver(() => resizeFrame());
-                observer.observe(document.body);
+        // Send the calculated height to Streamlit, falling back to postMessage
+        function postHeight(height) {
+            if (window.Streamlit && Streamlit.setFrameHeight) {
+                Streamlit.setFrameHeight(height);
+            } else {
+                window.parent.postMessage({
+                    type: 'streamlit:setFrameHeight',
+                    height,
+                    isStreamlitMessage: true
+                }, '*');
             }
         }
 
+        // Adjust iframe height so the dashboard fills the browser window
+        function resizeFrame() {
+            const docHeight = document.documentElement.scrollHeight;
+            const bodyHeight = document.body.scrollHeight;
+            const offsetHeight = Math.max(
+                document.documentElement.offsetHeight,
+                document.body.offsetHeight
+            );
+            const viewportHeight = window.visualViewport ? window.visualViewport.height : 0;
+            const height = Math.max(docHeight, bodyHeight, offsetHeight, viewportHeight, 1000) + 20;
+            postHeight(height);
+        }
 
-        // Initialize on load and set initial height
+        // Watch for changes and repeatedly set height to avoid race conditions
+        function setupFrameSizing() {
+            resizeFrame();
+            // run again in case Streamlit resets the height after initial render
+            setTimeout(resizeFrame, 100);
+
+            if (window.ResizeObserver) {
+                new ResizeObserver(resizeFrame).observe(document.body);
+            }
+
+            window.addEventListener('resize', resizeFrame);
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', resizeFrame);
+            }
+        }
+
         window.addEventListener('load', () => {
             init();
-            resizeFrame();
-            setupResizeObserver();
+            setupFrameSizing();
         });
-        window.addEventListener('resize', resizeFrame);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- paint the Streamlit page with the dashboard’s purple gradient and remove container padding so no white border remains
- fall back to `postMessage` when `Streamlit.setFrameHeight` isn’t available, eliminating the dependency on the external component library

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf739b0c8329a2541434c9b5f4a6