### PR TITLE
Simplify sizing logic for full-screen dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
 
         html, body {
             width: 100%;
-            min-height: 100%;
+            height: 100%;
+            min-height: 100vh;
         }
 
         body {
@@ -1255,31 +1256,20 @@
 
         // Adjust iframe height so the dashboard fills the browser window
         function resizeFrame() {
-            const docHeight = document.documentElement.scrollHeight;
-            const bodyHeight = document.body.scrollHeight;
-            const offsetHeight = Math.max(
-                document.documentElement.offsetHeight,
-                document.body.offsetHeight
+            const height = Math.max(
+                document.documentElement.scrollHeight,
+                document.body.scrollHeight,
+                window.innerHeight
             );
-            const viewportHeight = window.visualViewport ? window.visualViewport.height : 0;
-            const height = Math.max(docHeight, bodyHeight, offsetHeight, viewportHeight, 1000) + 20;
             postHeight(height);
         }
 
-        // Watch for changes and repeatedly set height to avoid race conditions
         function setupFrameSizing() {
             resizeFrame();
-            // run again in case Streamlit resets the height after initial render
-            setTimeout(resizeFrame, 100);
-
             if (window.ResizeObserver) {
                 new ResizeObserver(resizeFrame).observe(document.body);
             }
-
             window.addEventListener('resize', resizeFrame);
-            if (window.visualViewport) {
-                window.visualViewport.addEventListener('resize', resizeFrame);
-            }
         }
 
         window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Ensure page layout spans full viewport with explicit `height` and `min-height` rules
- Replace complex iframe resizing with simple calculation based on document and viewport heights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d51bab04832984a5563106b865e3