### PR TITLE
Simplify sizing logic for full-screen dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,8 @@ def main() -> None:
             html, body {
                 margin: 0;
                 padding: 0;
+                height: 100%;
+                min-height: 100vh;
                 background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             }
 
@@ -48,6 +50,14 @@ def main() -> None:
             /* Hide Streamlit's default header to remove extra white space */
             header[data-testid="stHeader"] {
                 display: none;
+            }
+
+            /* Fix the logout button to the bottom-left corner */
+            div.stButton > button:first-child {
+                position: fixed;
+                bottom: 20px;
+                left: 20px;
+                z-index: 1000;
             }
         </style>
         """,

--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
 
         html, body {
             width: 100%;
-            min-height: 100%;
+            height: 100%;
+            min-height: 100vh;
         }
 
         body {
@@ -1255,31 +1256,20 @@
 
         // Adjust iframe height so the dashboard fills the browser window
         function resizeFrame() {
-            const docHeight = document.documentElement.scrollHeight;
-            const bodyHeight = document.body.scrollHeight;
-            const offsetHeight = Math.max(
-                document.documentElement.offsetHeight,
-                document.body.offsetHeight
+            const height = Math.max(
+                document.documentElement.scrollHeight,
+                document.body.scrollHeight,
+                window.innerHeight
             );
-            const viewportHeight = window.visualViewport ? window.visualViewport.height : 0;
-            const height = Math.max(docHeight, bodyHeight, offsetHeight, viewportHeight, 1000) + 20;
             postHeight(height);
         }
 
-        // Watch for changes and repeatedly set height to avoid race conditions
         function setupFrameSizing() {
             resizeFrame();
-            // run again in case Streamlit resets the height after initial render
-            setTimeout(resizeFrame, 100);
-
             if (window.ResizeObserver) {
                 new ResizeObserver(resizeFrame).observe(document.body);
             }
-
             window.addEventListener('resize', resizeFrame);
-            if (window.visualViewport) {
-                window.visualViewport.addEventListener('resize', resizeFrame);
-            }
         }
 
         window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Ensure page layout spans full viewport with explicit `height` and `min-height` rules
- Replace complex iframe resizing with simple calculation based on document and viewport heights
- Anchor logout button to bottom-left with fixed positioning and extend background gradient

## Testing
- `pytest -q`
- `python -m streamlit run app.py --server.headless true --global.developmentMode=false`

------
https://chatgpt.com/codex/tasks/task_e_68b0d51bab04832984a5563106b865e3