### PR TITLE
Simplify sizing logic for full-screen dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,10 @@ def main() -> None:
             html, body {
                 margin: 0;
                 padding: 0;
-                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                height: 100%;
+                min-height: 100vh;
+                /* Highlight the outer container (formerly purple) in red */
+                background: red;
             }
 
             div[data-testid="stApp"] {
@@ -49,6 +52,14 @@ def main() -> None:
             header[data-testid="stHeader"] {
                 display: none;
             }
+
+            /* Fix the logout button to the bottom-left corner */
+            div.stButton > button:first-child {
+                position: fixed;
+                bottom: 20px;
+                left: 20px;
+                z-index: 1000;
+            }
         </style>
         """,
         unsafe_allow_html=True,
@@ -58,7 +69,8 @@ def main() -> None:
     with index_path.open(encoding="utf-8") as f:
         html = f.read()
 
-    st.components.v1.html(html, height=1000, scrolling=False)
+    # Initial height is 0; the embedded page will request the correct size
+    st.components.v1.html(html, height=0, scrolling=False)
 
     # Place logout button below the dashboard instead of at the top
     authenticator.logout("Logout", "main")

--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@
 
         html, body {
             width: 100%;
-            min-height: 100%;
+            height: 100%;
+            min-height: 100vh;
         }
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            padding: 20px;
+            background: blue;
         }
         
         .container {
@@ -29,7 +29,7 @@
             border-radius: 20px;
             box-shadow: 0 20px 60px rgba(0,0,0,0.3);
             padding: 30px;
-            min-height: calc(100vh - 40px);
+            min-height: 100vh;
         }
         
         .header {
@@ -1255,31 +1255,20 @@
 
         // Adjust iframe height so the dashboard fills the browser window
         function resizeFrame() {
-            const docHeight = document.documentElement.scrollHeight;
-            const bodyHeight = document.body.scrollHeight;
-            const offsetHeight = Math.max(
-                document.documentElement.offsetHeight,
-                document.body.offsetHeight
-            );
-            const viewportHeight = window.visualViewport ? window.visualViewport.height : 0;
-            const height = Math.max(docHeight, bodyHeight, offsetHeight, viewportHeight, 1000) + 20;
+            let height;
+            try {
+                // Use the outer window's height when embedded in Streamlit
+                height = window.parent.innerHeight;
+            } catch (e) {
+                // Fallback if parent is inaccessible
+                height = window.innerHeight;
+            }
             postHeight(height);
         }
 
-        // Watch for changes and repeatedly set height to avoid race conditions
         function setupFrameSizing() {
             resizeFrame();
-            // run again in case Streamlit resets the height after initial render
-            setTimeout(resizeFrame, 100);
-
-            if (window.ResizeObserver) {
-                new ResizeObserver(resizeFrame).observe(document.body);
-            }
-
             window.addEventListener('resize', resizeFrame);
-            if (window.visualViewport) {
-                window.visualViewport.addEventListener('resize', resizeFrame);
-            }
         }
 
         window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Highlight the outer Streamlit layer in red to expose the surrounding container
- Set the iframe height dynamically based on the parent window so the dashboard fills the browser vertically

## Testing
- `pytest -q`
- `python -m streamlit run app.py --server.headless true --global.developmentMode=false`

------
https://chatgpt.com/codex/tasks/task_e_68b0d51bab04832984a5563106b865e3