### PR TITLE
Remove custom app container for default Streamlit background

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,6 @@ def main() -> None:
     if not authenticated:
         st.stop()
     load_css()
-    st.markdown("<div class='app-container'>", unsafe_allow_html=True)
     st.title("Lumen Strategic Dashboard")
 
     with st.sidebar:
@@ -83,7 +82,6 @@ def main() -> None:
         authenticator.logout("Logout", "sidebar")
 
     create_draggable_matrix(st.session_state.get("username", "user"))
-    st.markdown("</div>", unsafe_allow_html=True)
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -18,18 +18,6 @@ def load_css() -> None:
             padding: 0;
             height: 100%;
             min-height: 100vh;
-            background: linear-gradient(135deg, #555, #ddd);
-        }
-
-        /* Container mimicking the original centered white card */
-        .app-container {
-            max-width: 1400px;
-            margin: 0 auto;
-            background: white;
-            border-radius: 20px;
-            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
-            padding: 30px;
-            min-height: 100vh;
         }
 
         div[data-testid="stApp"] {


### PR DESCRIPTION
## Summary
- Drop custom `.app-container` wrapper and styles
- Rely on default Streamlit background for the dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70671d8888329884d77c73d7660ec