### PR TITLE
Remove custom app container for default Streamlit background

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,6 @@ def main() -> None:
     if not authenticated:
         st.stop()
     load_css()
-    st.markdown("<div class='app-container'>", unsafe_allow_html=True)
     st.title("Lumen Strategic Dashboard")
 
     with st.sidebar:
@@ -83,7 +82,6 @@ def main() -> None:
         authenticator.logout("Logout", "sidebar")
 
     create_draggable_matrix(st.session_state.get("username", "user"))
-    st.markdown("</div>", unsafe_allow_html=True)
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import json
+import pandas as pd
 
 from streamlit_elements import elements, dashboard, html, mui, sync
 from streamlit_elements.core.callback import ElementsCallback
@@ -17,18 +18,6 @@ def load_css() -> None:
             margin: 0;
             padding: 0;
             height: 100%;
-            min-height: 100vh;
-            background: linear-gradient(135deg, #555, #ddd);
-        }
-
-        /* Container mimicking the original centered white card */
-        .app-container {
-            max-width: 1400px;
-            margin: 0 auto;
-            background: white;
-            border-radius: 20px;
-            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
-            padding: 30px;
             min-height: 100vh;
         }
 
@@ -91,8 +80,14 @@ def create_draggable_matrix(username: str) -> None:
     """Render initiatives as draggable "post-it" notes."""
     df = get_initiatives()
     if df.empty:
-        st.info("No initiatives added yet.")
-        return
+        st.info("No initiatives added yet. Showing sample initiatives.")
+        df = pd.DataFrame(
+            [
+                {"id": -1, "title": "Sample Initiative 1", "color": "#FFFB7D", "x": 20, "y": 80},
+                {"id": -2, "title": "Sample Initiative 2", "color": "#FFD6A5", "x": 50, "y": 50},
+                {"id": -3, "title": "Sample Initiative 3", "color": "#CBF3F0", "x": 80, "y": 20},
+            ]
+        )
 
     last_updated = get_last_updated()
     if "layout" not in st.session_state or st.session_state.get("layout_ts") != last_updated:
@@ -144,7 +139,9 @@ def create_draggable_matrix(username: str) -> None:
         if layout_json != st.session_state.get("_layout_snapshot"):
             st.session_state["_layout_snapshot"] = layout_json
             for item in st.session_state["layout"]:
-                update_position(int(item["i"]), float(item["x"]), float(item["y"]), username)
+                item_id = int(item["i"])
+                if item_id > 0:
+                    update_position(item_id, float(item["x"]), float(item["y"]), username)
 
     if "edit" in st.session_state:
         st.session_state["edit_initiative_id"] = int(st.session_state.pop("edit"))


### PR DESCRIPTION
## Summary
- Drop custom `.app-container` wrapper and styles
- Rely on default Streamlit background for the dashboard
- Render draggable grid even when there are no initiatives
- Populate sample initiatives when the database is empty for easier testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70671d8888329884d77c73d7660ec