### PR TITLE
Display version and ensure grid rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,28 @@
 import streamlit as st
+import subprocess
 
 from auth import login
 from db import get_initiative, init_db, upsert_initiative
 from ui import load_css, create_draggable_matrix
+
+
+def _get_version() -> str:
+    """Return short version information from git.
+
+    Uses the commit count combined with the short hash so the value
+    automatically changes with every commit. Falls back to ``"dev"`` if
+    git is unavailable so the page always renders.
+    """
+    try:
+        count = subprocess.check_output(
+            ["git", "rev-list", "--count", "HEAD"], text=True
+        ).strip()
+        short = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True
+        ).strip()
+        return f"{count}-{short}"
+    except Exception:
+        return "dev"
 
 
 def main() -> None:
@@ -25,8 +45,8 @@ def main() -> None:
     if not authenticated:
         st.stop()
     load_css()
-    st.markdown("<div class='app-container'>", unsafe_allow_html=True)
     st.title("Lumen Strategic Dashboard")
+    st.caption(f"Version: {_get_version()}")
 
     with st.sidebar:
         st.header("Add / Update Initiative")
@@ -83,7 +103,6 @@ def main() -> None:
         authenticator.logout("Logout", "sidebar")
 
     create_draggable_matrix(st.session_state.get("username", "user"))
-    st.markdown("</div>", unsafe_allow_html=True)
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import json
+import pandas as pd
 
 from streamlit_elements import elements, dashboard, html, mui, sync
 from streamlit_elements.core.callback import ElementsCallback
@@ -18,38 +19,6 @@ def load_css() -> None:
             padding: 0;
             height: 100%;
             min-height: 100vh;
-            background: linear-gradient(135deg, #555, #ddd);
-        }
-
-        /* Container mimicking the original centered white card */
-        .app-container {
-            max-width: 1400px;
-            margin: 0 auto;
-            background: white;
-            border-radius: 20px;
-            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
-            padding: 30px;
-            min-height: 100vh;
-        }
-
-        div[data-testid="stApp"] {
-            background: transparent;
-        }
-
-        div[data-testid="stAppViewContainer"] {
-            padding: 0;
-            background: transparent;
-        }
-
-        div[data-testid="stAppViewContainer"] > .main {
-            padding: 0;
-            background: transparent;
-        }
-
-        div[data-testid="stAppViewContainer"] > .main .block-container {
-            padding: 0;
-            margin: 0;
-            background: transparent;
         }
 
         header[data-testid="stHeader"] {
@@ -91,8 +60,14 @@ def create_draggable_matrix(username: str) -> None:
     """Render initiatives as draggable "post-it" notes."""
     df = get_initiatives()
     if df.empty:
-        st.info("No initiatives added yet.")
-        return
+        st.info("No initiatives added yet. Use the form to add one.")
+        df = pd.DataFrame(
+            [
+                {"id": -1, "title": "Example Initiative 1", "color": "#FFFB7D", "x": 25, "y": 75},
+                {"id": -2, "title": "Example Initiative 2", "color": "#7DFBFF", "x": 50, "y": 50},
+                {"id": -3, "title": "Example Initiative 3", "color": "#B3FF7D", "x": 75, "y": 25},
+            ]
+        )
 
     last_updated = get_last_updated()
     if "layout" not in st.session_state or st.session_state.get("layout_ts") != last_updated:
@@ -105,46 +80,92 @@ def create_draggable_matrix(username: str) -> None:
     layout = st.session_state.get("layout", [])
 
     with elements("board"):
-        # ``dashboard.Grid`` acts as a context manager. The previous implementation
-        # instantiated it without entering the context, which resulted in an empty
-        # white canvas being rendered on Streamlit Cloud. By using ``with`` the
-        # grid properly wraps each sticky note allowing them to display and drag.
-        with dashboard.Grid(
-            layout,
-            onLayoutChange=sync("layout"),
-            cols=100,
-            rowHeight=5,
-            isDraggable=True,
-            isResizable=False,
-            style={"width": "100%", "minHeight": 500},
-        ):
-            for row in df.itertuples():
-                edit_callback = ElementsCallback(
-                    lambda r_id=row.id: st.session_state.update(edit=r_id)
-                )
-                with html.div(
-                    key=str(row.id),
-                    style={
-                        "backgroundColor": row.color or "#FFFB7D",
-                        "width": "100%",
-                        "height": "100%",
-                        "padding": "8px",
-                        "border": "1px solid #e0e0e0",
-                        "borderRadius": "4px",
-                        "boxShadow": "0 2px 4px rgba(0,0,0,0.2)",
-                        "cursor": "move",
-                        "userSelect": "none",
-                    },
-                    onDoubleClick=edit_callback,
-                ):
-                    mui.Typography(row.title, variant="body2")
+        grid_style = {
+            "position": "relative",
+            "width": "100%",
+            "height": "80vh",
+            "backgroundColor": "#fff",
+            "backgroundImage": (
+                "linear-gradient(#d0d0d0 0 0), "
+                "linear-gradient(#d0d0d0 0 0), "
+                "linear-gradient(90deg, #d0d0d0 0 0), "
+                "linear-gradient(90deg, #d0d0d0 0 0)"
+            ),
+            "backgroundSize": "100% 2px, 100% 2px, 2px 100%, 2px 100%",
+            "backgroundPosition": "0 33.33%, 0 66.66%, 33.33% 0, 66.66% 0",
+            "backgroundRepeat": "no-repeat",
+            "border": "1px solid #e0e0e0",
+            "overflow": "visible",
+        }
+        with html.div(style=grid_style):
+            with dashboard.Grid(
+                layout,
+                onLayoutChange=sync("layout"),
+                cols=100,
+                rowHeight=8,
+                isDraggable=True,
+                isResizable=False,
+                style={
+                    "position": "absolute",
+                    "top": 0,
+                    "left": 0,
+                    "right": 0,
+                    "bottom": 0,
+                    "zIndex": 1,
+                },
+            ):
+                for row in df.itertuples():
+                    edit_callback = ElementsCallback(lambda r_id=row.id: st.session_state.update(edit=r_id))
+                    with html.div(
+                        key=str(row.id),
+                        style={
+                            "backgroundColor": row.color or "#FFFB7D",
+                            "width": "100%",
+                            "height": "100%",
+                            "padding": "8px",
+                            "border": "1px solid #e0e0e0",
+                            "borderRadius": "4px",
+                            "boxShadow": "0 2px 4px rgba(0,0,0,0.2)",
+                            "cursor": "move",
+                            "userSelect": "none",
+                        },
+                        onDoubleClick=edit_callback,
+                    ):
+                        mui.Typography(row.title, variant="body2")
+
+            html.div(
+                "Effort",
+                style={
+                    "position": "absolute",
+                    "bottom": "-30px",
+                    "left": "50%",
+                    "transform": "translateX(-50%)",
+                    "fontWeight": "bold",
+                    "pointerEvents": "none",
+                    "zIndex": 2,
+                },
+            )
+            html.div(
+                "Value",
+                style={
+                    "position": "absolute",
+                    "top": "50%",
+                    "left": "-40px",
+                    "transform": "translateY(-50%) rotate(-90deg)",
+                    "fontWeight": "bold",
+                    "pointerEvents": "none",
+                    "zIndex": 2,
+                },
+            )
 
     if "layout" in st.session_state:
         layout_json = json.dumps(st.session_state["layout"])
         if layout_json != st.session_state.get("_layout_snapshot"):
             st.session_state["_layout_snapshot"] = layout_json
             for item in st.session_state["layout"]:
-                update_position(int(item["i"]), float(item["x"]), float(item["y"]), username)
+                item_id = int(item["i"])
+                if item_id > 0:
+                    update_position(item_id, float(item["x"]), float(item["y"]), username)
 
     if "edit" in st.session_state:
         st.session_state["edit_initiative_id"] = int(st.session_state.pop("edit"))


### PR DESCRIPTION
## Summary
- Show commit-based version tag so UI changes are visible on each deploy
- Draw initiative board grid using background gradients for reliable display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70671d8888329884d77c73d7660ec